### PR TITLE
Orange/Riley/Ema-link translation fixes

### DIFF
--- a/Dependencies/rileylink_ios/RileyLinkKitUI/Base.lproj/Localizable.strings
+++ b/Dependencies/rileylink_ios/RileyLinkKitUI/Base.lproj/Localizable.strings
@@ -85,6 +85,12 @@
 /* The title of the cell for sounding device finding piezo */
 "Find Device" = "Find Device";
 
+/* The title of the cell for connection LED */
+"Connection LED" = "Connection LED";
+
+/* The title of the cell for connection vibration */
+"Connection Vibration" = "Connection Vibration";
+
 /* Detail text when battery alert disabled. */
 "Off" = "Off";
 

--- a/Dependencies/rileylink_ios/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
+++ b/Dependencies/rileylink_ios/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
@@ -779,8 +779,8 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
         case .alert:
             switch AlertRow(rawValue: indexPath.row)! {
             case .battery:
-                let alert = UIAlertController.init(title: "Battery level Alert", message: nil, preferredStyle: .actionSheet)
-                let action = UIAlertAction.init(title: "OFF", style: .default) { _ in
+                let alert = UIAlertController.init(title: LocalizedString("Battery level Alert", comment: "Header of list showing battery level alert options"), message: nil, preferredStyle: .actionSheet)
+                let action = UIAlertAction.init(title: LocalizedString("OFF", comment: "Battery level alert OFF in list of options"), style: .default) { _ in
                     self.batteryAlertLevel = nil
                     self.tableView.reloadData()
                 }

--- a/Dependencies/rileylink_ios/RileyLinkKitUI/sv.lproj/Localizable.strings
+++ b/Dependencies/rileylink_ios/RileyLinkKitUI/sv.lproj/Localizable.strings
@@ -50,7 +50,7 @@
 "Voltage" = "Spänning (V)";
 
 //* "The title of the section for alerts" */
-"Alert" = "Alert";
+"Alert" = "Varning";
 
 /* The title of the cell showing Low Battery Alert */
 "Low Battery Alert" = "Låg batterinivå";
@@ -84,6 +84,12 @@
 
 /* The title of the cell for sounding device finding piezo */
 "Find Device" = "Hitta enhet";
+
+/* The title of the cell for connection LED */
+"Connection LED" = "Anslutnings-LED";
+
+/* The title of the cell for connection vibration */
+"Connection Vibration" = "Anslutningsvibration";
 
 /* Detail text when battery alert disabled. */
 "Off" = "Av";


### PR DESCRIPTION
Mixing of both NSLocalizedString and LocalizedString made half of translations not working. 
Adding necessary source strings to Base.lproj.
Adding Swedish translations to new link-strings.
