### PR TITLE
Add settings to enable adjustment of basal based on TDD.

### DIFF
--- a/FreeAPS/Sources/Models/Preferences.swift
+++ b/FreeAPS/Sources/Models/Preferences.swift
@@ -68,6 +68,7 @@ struct Preferences: JSON {
     var useNewFormula: Bool = false
     var useWeightedAverage: Bool = false
     var weightPercentage: Decimal = 0.65
+    var tddAdjBasal: Bool = false
 }
 
 extension Preferences {
@@ -138,6 +139,7 @@ extension Preferences {
         case useNewFormula
         case useWeightedAverage
         case weightPercentage
+        case tddAdjBasal
     }
 }
 

--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
@@ -136,6 +136,15 @@ extension PreferencesEditor {
                         comment: "Weight of past 24 hours of TDD"
                     ),
                     settable: self
+                ),
+                Field(
+                    displayName: "Enable TDD-adjusted basal",
+                    type: .boolean(keypath: \.tddAdjBasal),
+                    infoText: NSLocalizedString(
+                        "Enable adjustment of basal based on the ratio of 24 h : 7 day average TDD",
+                        comment: "Enable adjustment of basal based on the ratio of 24 h : 7 day average TDD"
+                    ),
+                    settable: self
                 )
             ]
 


### PR DESCRIPTION
Adjust basal based on the ratio of 24 h : 7 day average TDD.

( could consider using the ratio of  weightedAverage : 7 day average TDD instead for a more moderate adjustment )