### PR TITLE
Hide / comment out Auto ISF settings

### DIFF
--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
@@ -454,182 +454,182 @@ extension PreferencesEditor {
                 )
             ]
 
-            let autoISF = [
-                Field(
-                    displayName: "Enable AutoISF",
-                    type: .boolean(keypath: \.autoisf),
-                    infoText: NSLocalizedString(
-                        "Defaults to false. Adapt ISF when glucose is stuck at high levels, only works without COB.\n\nRead up on:\nhttps://github.com/ga-zelle/autoISF/tree/2.8.2",
-                        comment: "Enable AutoISF"
-                    ),
-                    settable: self
-                )
-            ]
+            /*    let autoISF = [
+                 Field(
+                     displayName: "Enable AutoISF",
+                     type: .boolean(keypath: \.autoisf),
+                     infoText: NSLocalizedString(
+                         "Defaults to false. Adapt ISF when glucose is stuck at high levels, only works without COB.\n\nRead up on:\nhttps://github.com/ga-zelle/autoISF/tree/2.8.2",
+                         comment: "Enable AutoISF"
+                     ),
+                     settable: self
+                 )
+             ]
 
-            let autoISFsettings = [
-                Field(
-                    displayName: "Enable Floating Carbs",
-                    type: .boolean(keypath: \.floatingcarbs),
-                    infoText: NSLocalizedString(
-                        "Defaults to false. If true, then dose slightly more aggressively by using all entered carbs for calculating COBpredBGs. This avoids backing off too quickly as COB decays. Even with this option, oref0 still switches gradually from using COBpredBGs to UAMpredBGs proportionally to how many carbs are left as COB. Summary: use all entered carbs in the future for predBGs & don't decay them as COB, only once they are actual.",
-                        comment: "Floating Carbs"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "Enable AutoISF with COB",
-                    type: .boolean(keypath: \.enableautoISFwithCOB),
-                    infoText: NSLocalizedString(
-                        "Enables autoISF not just for UAM, but also with COB\n\nRead up on:\nhttps://github.com/ga-zelle/autoISF/tree/2.8.2_dev_parabola",
-                        comment: "Enable autoISF with COB"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "Enable BG acceleartion in AutoISF2.2",
-                    type: .boolean(keypath: \.enableBGacceleration),
-                    infoText: NSLocalizedString(
-                        "Enables the BG acceleration adaptiions for autoISF\n\nRead up on:\nhttps://github.com/ga-zelle/autoISF/tree/2.8.2dev_ai2.2",
-                        comment: "Enable BG accel in autoISF"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "AutoISF HourlyMaxChange",
-                    type: .decimal(keypath: \.autoISFhourlyChange),
-                    infoText: NSLocalizedString(
-                        "Defaults to false. Rate at which autoISF grows per hour assuming bg is twice target. When value = 1.0, ISF is reduced to 50% after 1 hour of BG at 2x target.",
-                        comment: "AutoISF HourlyMaxChange"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "AutoISF Max",
-                    type: .decimal(keypath: \.autoISFmax),
-                    infoText: NSLocalizedString(
-                        "Multiplier cap on how high the autoISF ratio can be and therefore how low it can adjust ISF.",
-                        comment: "AutoISF Max"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "SMB Max RangeExtension",
-                    type: .decimal(keypath: \.smbMaxRangeExtension),
-                    infoText: NSLocalizedString(
-                        "Default value: 1. This is another key OpenAPS safety cap, and specifies by what factor you can exceed the regular 120 maxSMB/maxUAM minutes. Increase this experimental value slowly and with caution. Available only when autoISF is enabled.",
-                        comment: "SMB Max RangeExtension"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "SMB DeliveryRatio BG Range",
-                    type: .decimal(keypath: \.smbDeliveryRatioBGrange),
-                    infoText: NSLocalizedString(
-                        "Default value: 0, Sensible is bteween 40 and 120. The linearly increasing SMB delivery ratio is mapped to the glucose range [target_bg, target_bg+bg_range]. At target_bg the SMB ratio is smb_delivery_ratio_min, at target_bg+bg_range it is smb_delivery_ratio_max. With 0 the linearly increasing SMB ratio is disabled and the fix smb_delivery_ratio is used.",
-                        comment: "SMB DeliveryRatio BG Range"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "SMB DeliveryRatio BG Minimum",
-                    type: .decimal(keypath: \.smbDeliveryRatioMin),
-                    infoText: NSLocalizedString(
-                        "Default value: 0.5 This is the lower end of a linearly increasing SMB Delivery Ratio rather than the fix value above in SMB DeliveryRatio.",
-                        comment: "SMB DeliveryRatio Minimum"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "SMB DeliveryRatio BG Maximum",
-                    type: .decimal(keypath: \.smbDeliveryRatioMax),
-                    infoText: NSLocalizedString(
-                        "Default value: 0.5 This is the higher end of a linearly increasing SMB Delivery Ratio rather than the fix value above in SMB DeliveryRatio.",
-                        comment: "SMB DeliveryRatio Minimum"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "ISF weight while BG accelerates",
-                    type: .decimal(keypath: \.bgAccelISFweight),
-                    infoText: NSLocalizedString(
-                        "Default value: 0. This is the weight applied while glucose accelerates and which strengthens ISF. With 0 this contribution is effectively disabled. 0.15 might be a good starting point.",
-                        comment: "ISF acceleration weight"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "ISF weight while BG decelerates",
-                    type: .decimal(keypath: \.bgBrakeISFweight),
-                    infoText: NSLocalizedString(
-                        "Default value: 0. This is the weight applied while glucose decelerates and which weakens ISF. With 0 this contribution is effectively disabled. 0.15 might be a good starting point.",
-                        comment: "ISF decceleration weight"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "AutoISF Min",
-                    type: .decimal(keypath: \.autoISFmin),
-                    infoText: NSLocalizedString(
-                        "This is a multiplier cap for autoISF to set a limit on how low the autoISF ratio can be, which in turn determines how high it can adjust ISF.",
-                        comment: "AutoISF Min"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "ISF weight for higher BG's",
-                    type: .decimal(keypath: \.higherISFrangeWeight),
-                    infoText: NSLocalizedString(
-                        "Default value: 0.0 This is the weight applied to the polygon which adapts ISF if glucose is above target. With 0.0 the effect is effectively disabled.",
-                        comment: "ISF high BG weight"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "ISF weight for lower BG's",
-                    type: .decimal(keypath: \.lowerISFrangeWeight),
-                    infoText: NSLocalizedString(
-                        "Default value: 0.0 This is the weight applied to the polygon which adapts ISF if glucose is below target. With 0.0 the effect is effectively disabled.",
-                        comment: "ISF low BG weight"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "ISF weight for higher BG deltas",
-                    type: .decimal(keypath: \.deltaISFrangeWeight),
-                    infoText: NSLocalizedString(
-                        "Default value: 0.0 This is the weight applied to the polygon which adapts ISF higher deltas. With 0.0 the effect is effectively disabled.",
-                        comment: "ISF higher delta BG weight"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "Enable always postprandial ISF adaption",
-                    type: .boolean(keypath: \.postMealISFalways),
-                    infoText: NSLocalizedString(
-                        "Enable the postprandial ISF adaptation all the time regardless of when the last meal was taken.",
-                        comment: "Enable postprandial ISF always"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "ISF weight for postprandial BG rise",
-                    type: .decimal(keypath: \.postMealISFweight),
-                    infoText: NSLocalizedString(
-                        "Default value: 0 This is the weight applied to the linear slope while glucose rises and  which adapts ISF. With 0 this contribution is effectively disabled.",
-                        comment: "ISF postprandial weight"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "Duration ISF postprandial adaption",
-                    type: .decimal(keypath: \.postMealISFduration),
-                    infoText: NSLocalizedString(
-                        "Default value: 3 This is the duration in hours how long after a meal the effect will be active. Oref will delete carb timing after 10 hours latest no matter what you enter.",
-                        comment: "ISF postprandial change duration"
-                    ),
-                    settable: self
-                )
-            ]
+             let autoISFsettings = [
+                 Field(
+                     displayName: "Enable Floating Carbs",
+                     type: .boolean(keypath: \.floatingcarbs),
+                     infoText: NSLocalizedString(
+                         "Defaults to false. If true, then dose slightly more aggressively by using all entered carbs for calculating COBpredBGs. This avoids backing off too quickly as COB decays. Even with this option, oref0 still switches gradually from using COBpredBGs to UAMpredBGs proportionally to how many carbs are left as COB. Summary: use all entered carbs in the future for predBGs & don't decay them as COB, only once they are actual.",
+                         comment: "Floating Carbs"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "Enable AutoISF with COB",
+                     type: .boolean(keypath: \.enableautoISFwithCOB),
+                     infoText: NSLocalizedString(
+                         "Enables autoISF not just for UAM, but also with COB\n\nRead up on:\nhttps://github.com/ga-zelle/autoISF/tree/2.8.2_dev_parabola",
+                         comment: "Enable autoISF with COB"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "Enable BG acceleartion in AutoISF2.2",
+                     type: .boolean(keypath: \.enableBGacceleration),
+                     infoText: NSLocalizedString(
+                         "Enables the BG acceleration adaptiions for autoISF\n\nRead up on:\nhttps://github.com/ga-zelle/autoISF/tree/2.8.2dev_ai2.2",
+                         comment: "Enable BG accel in autoISF"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "AutoISF HourlyMaxChange",
+                     type: .decimal(keypath: \.autoISFhourlyChange),
+                     infoText: NSLocalizedString(
+                         "Defaults to false. Rate at which autoISF grows per hour assuming bg is twice target. When value = 1.0, ISF is reduced to 50% after 1 hour of BG at 2x target.",
+                         comment: "AutoISF HourlyMaxChange"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "AutoISF Max",
+                     type: .decimal(keypath: \.autoISFmax),
+                     infoText: NSLocalizedString(
+                         "Multiplier cap on how high the autoISF ratio can be and therefore how low it can adjust ISF.",
+                         comment: "AutoISF Max"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "SMB Max RangeExtension",
+                     type: .decimal(keypath: \.smbMaxRangeExtension),
+                     infoText: NSLocalizedString(
+                         "Default value: 1. This is another key OpenAPS safety cap, and specifies by what factor you can exceed the regular 120 maxSMB/maxUAM minutes. Increase this experimental value slowly and with caution. Available only when autoISF is enabled.",
+                         comment: "SMB Max RangeExtension"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "SMB DeliveryRatio BG Range",
+                     type: .decimal(keypath: \.smbDeliveryRatioBGrange),
+                     infoText: NSLocalizedString(
+                         "Default value: 0, Sensible is bteween 40 and 120. The linearly increasing SMB delivery ratio is mapped to the glucose range [target_bg, target_bg+bg_range]. At target_bg the SMB ratio is smb_delivery_ratio_min, at target_bg+bg_range it is smb_delivery_ratio_max. With 0 the linearly increasing SMB ratio is disabled and the fix smb_delivery_ratio is used.",
+                         comment: "SMB DeliveryRatio BG Range"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "SMB DeliveryRatio BG Minimum",
+                     type: .decimal(keypath: \.smbDeliveryRatioMin),
+                     infoText: NSLocalizedString(
+                         "Default value: 0.5 This is the lower end of a linearly increasing SMB Delivery Ratio rather than the fix value above in SMB DeliveryRatio.",
+                         comment: "SMB DeliveryRatio Minimum"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "SMB DeliveryRatio BG Maximum",
+                     type: .decimal(keypath: \.smbDeliveryRatioMax),
+                     infoText: NSLocalizedString(
+                         "Default value: 0.5 This is the higher end of a linearly increasing SMB Delivery Ratio rather than the fix value above in SMB DeliveryRatio.",
+                         comment: "SMB DeliveryRatio Minimum"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "ISF weight while BG accelerates",
+                     type: .decimal(keypath: \.bgAccelISFweight),
+                     infoText: NSLocalizedString(
+                         "Default value: 0. This is the weight applied while glucose accelerates and which strengthens ISF. With 0 this contribution is effectively disabled. 0.15 might be a good starting point.",
+                         comment: "ISF acceleration weight"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "ISF weight while BG decelerates",
+                     type: .decimal(keypath: \.bgBrakeISFweight),
+                     infoText: NSLocalizedString(
+                         "Default value: 0. This is the weight applied while glucose decelerates and which weakens ISF. With 0 this contribution is effectively disabled. 0.15 might be a good starting point.",
+                         comment: "ISF decceleration weight"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "AutoISF Min",
+                     type: .decimal(keypath: \.autoISFmin),
+                     infoText: NSLocalizedString(
+                         "This is a multiplier cap for autoISF to set a limit on how low the autoISF ratio can be, which in turn determines how high it can adjust ISF.",
+                         comment: "AutoISF Min"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "ISF weight for higher BG's",
+                     type: .decimal(keypath: \.higherISFrangeWeight),
+                     infoText: NSLocalizedString(
+                         "Default value: 0.0 This is the weight applied to the polygon which adapts ISF if glucose is above target. With 0.0 the effect is effectively disabled.",
+                         comment: "ISF high BG weight"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "ISF weight for lower BG's",
+                     type: .decimal(keypath: \.lowerISFrangeWeight),
+                     infoText: NSLocalizedString(
+                         "Default value: 0.0 This is the weight applied to the polygon which adapts ISF if glucose is below target. With 0.0 the effect is effectively disabled.",
+                         comment: "ISF low BG weight"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "ISF weight for higher BG deltas",
+                     type: .decimal(keypath: \.deltaISFrangeWeight),
+                     infoText: NSLocalizedString(
+                         "Default value: 0.0 This is the weight applied to the polygon which adapts ISF higher deltas. With 0.0 the effect is effectively disabled.",
+                         comment: "ISF higher delta BG weight"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "Enable always postprandial ISF adaption",
+                     type: .boolean(keypath: \.postMealISFalways),
+                     infoText: NSLocalizedString(
+                         "Enable the postprandial ISF adaptation all the time regardless of when the last meal was taken.",
+                         comment: "Enable postprandial ISF always"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "ISF weight for postprandial BG rise",
+                     type: .decimal(keypath: \.postMealISFweight),
+                     infoText: NSLocalizedString(
+                         "Default value: 0 This is the weight applied to the linear slope while glucose rises and  which adapts ISF. With 0 this contribution is effectively disabled.",
+                         comment: "ISF postprandial weight"
+                     ),
+                     settable: self
+                 ),
+                 Field(
+                     displayName: "Duration ISF postprandial adaption",
+                     type: .decimal(keypath: \.postMealISFduration),
+                     infoText: NSLocalizedString(
+                         "Default value: 3 This is the duration in hours how long after a meal the effect will be active. Oref will delete carb timing after 10 hours latest no matter what you enter.",
+                         comment: "ISF postprandial change duration"
+                     ),
+                     settable: self
+                 )
+             ] */
 
             sections = [
                 FieldSection(
@@ -649,18 +649,18 @@ extension PreferencesEditor {
                 FieldSection(
                     displayName: NSLocalizedString("OpenAPS other settings", comment: "OpenAPS other settings"),
                     fields: otherSettings
-                ),
-                FieldSection(
-                    displayName: NSLocalizedString("Use Auto ISF", comment: "Switch on/off experimental stuff"),
-                    fields: autoISF
-                ),
-                FieldSection(
-                    displayName: NSLocalizedString(
-                        "Auto ISF Settings. Forget about these if Auto ISF is toggled off",
-                        comment: "AutoISF Settings"
-                    ),
-                    fields: autoISFsettings
-                )
+                ) /* ,
+                 FieldSection(
+                     displayName: NSLocalizedString("Use Auto ISF", comment: "Switch on/off experimental stuff"),
+                     fields: autoISF
+                 ),
+                 FieldSection(
+                     displayName: NSLocalizedString(
+                         "Auto ISF Settings. Forget about these if Auto ISF is toggled off",
+                         comment: "AutoISF Settings"
+                     ),
+                     fields: autoISFsettings
+                 ) */
             ]
         }
 


### PR DESCRIPTION
A potential solution to scale down the settings monster. Users who really want to use aISF can revert this one commit, or uncomment the settings. 

Might cause som issues if people have already enabled aISF, but a rebuild after reverting would fix that.