### PR TITLE
Add conditional code to allow for checkpointing to the log file

### DIFF
--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/BluetoothManager.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/BluetoothManager.swift
@@ -136,7 +136,9 @@ class BluetoothManager: NSObject {
         var device: OmniBLE! = devices.first(where: { $0.manager.peripheral.identifier == peripheral.identifier })
 
         if let device = device {
+#if LOG_DEFAULT
             log.default("Matched peripheral %{public}@ to existing device: %{public}@", peripheral, String(describing: device))
+#endif
             device.manager.peripheral = peripheral
             if let podAdvertisement = podAdvertisement {
                 device.advertisement = podAdvertisement
@@ -170,7 +172,9 @@ class BluetoothManager: NSObject {
                 if !autoConnectIDs.contains(peripheral.identifier.uuidString) &&
                    (peripheral.state == .connected || peripheral.state == .connecting)
                 {
+#if LOG_DEFAULT
                     log.default("Disconnecting from peripheral: %{public}@", peripheral)
+#endif
                     manager.cancelPeripheralConnection(peripheral)
                 }
             }
@@ -216,7 +220,9 @@ class BluetoothManager: NSObject {
     private func discoverPods(_ completion: @escaping (BluetoothManagerError?) -> Void) {
         dispatchPrecondition(condition: .onQueue(managerQueue))
 
+#if LOG_DEFAULT
         log.default("discoverPods()")
+#endif
         
 
         guard manager.state == .poweredOn else {
@@ -239,12 +245,16 @@ class BluetoothManager: NSObject {
     }
     
     private func startScanning() {
+#if LOG_DEFAULT
         log.default("Start scanning")
+#endif 
         manager.scanForPeripherals(withServices: [OmnipodServiceUUID.advertisement.cbUUID], options: nil)
     }
 
     private func stopScanning() {
+#if LOG_DEFAULT
         log.default("Stop scanning")
+#endif
         manager.stopScan()
     }
 
@@ -279,7 +289,9 @@ extension BluetoothManager: CBCentralManagerDelegate {
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         dispatchPrecondition(condition: .onQueue(managerQueue))
 
+#if LOG_DEFAULT
         log.default("%{public}@: %{public}@", #function, String(describing: central.state.rawValue))
+#endif
 
         if case .poweredOn = central.state {
             // bluetooth may have reset; update peripheral references
@@ -339,7 +351,9 @@ extension BluetoothManager: CBCentralManagerDelegate {
             
             if discoveryModeEnabled && peripheral.state == .disconnected && podAdvertisement.pairable {
                 // Connect to any pairable device, during discovery
+#if LOG_DEFAULT
                 log.default("Connecting to pairable device %{public} in discovery mode", peripheral)
+#endif
                 manager.connect(peripheral, options: nil)
             } else if autoConnectIDs.contains(peripheral.identifier.uuidString) && peripheral.state == .disconnected {
 #if LOG_DEBUG

--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/BluetoothManager.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/BluetoothManager.swift
@@ -191,7 +191,9 @@ class BluetoothManager: NSObject {
     
     private func updateConnections() {
         guard manager.state == .poweredOn else {
+#if LOG_DEBUG
             log.debug("Skipping updateConnections until state is poweredOn")
+#endif
             return
         }
         
@@ -283,7 +285,9 @@ extension BluetoothManager: CBCentralManagerDelegate {
             // bluetooth may have reset; update peripheral references
             for device in devices {
                 if let newPeripheral = central.retrievePeripherals(withIdentifiers: [device.manager.peripheral.identifier]).first {
+#if LOG_DEBUG
                     log.debug("Re-connecting to known peripheral %{public}@", newPeripheral.identifier.uuidString)
+#endif
                     device.manager.peripheral = newPeripheral
                     central.connect(newPeripheral)
                 }
@@ -326,7 +330,9 @@ extension BluetoothManager: CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
         dispatchPrecondition(condition: .onQueue(managerQueue))
 
+#if LOG_DEBUG
         log.debug("%{public}@: %{public}@, %{public}@", #function, peripheral, advertisementData)
+#endif
         
         if let podAdvertisement = PodAdvertisement(advertisementData) {
             addPeripheral(peripheral, podAdvertisement: podAdvertisement)
@@ -336,7 +342,9 @@ extension BluetoothManager: CBCentralManagerDelegate {
                 log.default("Connecting to pairable device %{public} in discovery mode", peripheral)
                 manager.connect(peripheral, options: nil)
             } else if autoConnectIDs.contains(peripheral.identifier.uuidString) && peripheral.state == .disconnected {
+#if LOG_DEBUG
                 log.debug("Reonnecting to autoconnect device")
+#endif
                 manager.connect(peripheral, options: nil)
             } else {
                 log.info("Ignoring paired or unconnectable peripheral: %{public}@", peripheral)
@@ -346,7 +354,9 @@ extension BluetoothManager: CBCentralManagerDelegate {
         }
         
         if !discoveryModeEnabled && central.isScanning && hasDiscoveredAllAutoConnectDevices {
+#if LOG_DEBUG
             log.debug("All peripherals discovered")
+#endif
             stopScanning()
         }
     }
@@ -354,7 +364,9 @@ extension BluetoothManager: CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         dispatchPrecondition(condition: .onQueue(managerQueue))
 
+#if LOG_DEBUG
         log.debug("%{public}@: %{public}@", #function, peripheral)
+#endif
         
         // Proxy connection events to peripheral manager
         for device in devices where device.manager.peripheral.identifier == peripheral.identifier {
@@ -365,7 +377,9 @@ extension BluetoothManager: CBCentralManagerDelegate {
 
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
         dispatchPrecondition(condition: .onQueue(managerQueue))
+#if LOG_DEBUG
         log.debug("%{public}@: error=%{public}@ %{public}@", #function, error?.localizedDescription ?? "None", peripheral)
+#endif
 
         // Proxy disconnection events to peripheral manager
         for device in devices where device.manager.peripheral.identifier == peripheral.identifier {
@@ -375,7 +389,9 @@ extension BluetoothManager: CBCentralManagerDelegate {
         connectionDelegate?.omnipodPeripheralDidDisconnect(peripheral: peripheral, error: error)
 
         if autoConnectIDs.contains(peripheral.identifier.uuidString) {
+#if LOG_DEBUG
             log.debug("Reconnecting disconnected autoconnect peripheral")
+#endif
             central.connect(peripheral, options: nil)
         }
     }

--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/BluetoothServices.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/BluetoothServices.swift
@@ -56,7 +56,9 @@ extension PeripheralManager.Configuration {
                     guard let characteristic = manager.peripheral.getCommandCharacteristic() else { return }
                     guard let value = characteristic.value else { return }
 
+#if LOG_DEFAULT
                     manager.log.default("CMD <<< %{public}@", value.hexadecimalString)
+#endif
                     manager.queueLock.lock()
                     manager.cmdQueue.append(value)
                     manager.queueLock.signal()
@@ -66,7 +68,9 @@ extension PeripheralManager.Configuration {
                     guard let characteristic = manager.peripheral.getDataCharacteristic() else { return }
                     guard let value = characteristic.value else { return }
 
+#if LOG_DEFAULT
                     manager.log.default("DATA <<< %{public}@", value.hexadecimalString)
+#endif
                     manager.queueLock.lock()
                     manager.dataQueue.append(value)
                     manager.queueLock.signal()

--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/EnDecrypt/EnDecrypt.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/EnDecrypt/EnDecrypt.swift
@@ -26,15 +26,19 @@ class EnDecrypt {
         let header = msg.asData(forEncryption: false).subdata(in: 0..<16)
 
         let n = nonce.toData(sqn: nonceSeq, podReceiving: false)
+#if LOG_DEBUG
         log.debug("Decrypt ck %@", ck.hexadecimalString)
         log.debug("Decrypt header %@", header.hexadecimalString)
         log.debug("Decrypt payload: %@", payload.hexadecimalString)
         log.debug("Decrypt Nonce %@", n.hexadecimalString)
         log.debug("Decrypt Tag: %@", Data(payload).subdata(in: (payload.count - MAC_SIZE)..<payload.count).hexadecimalString)
+#endif
         let ccm = CCM(iv: n.bytes, tagLength: MAC_SIZE, messageLength: payload.count - MAC_SIZE, additionalAuthenticatedData: header.bytes)
         let aes = try AES(key: ck.bytes, blockMode: ccm, padding: .noPadding)
         let decryptedPayload = try aes.decrypt(payload.bytes)
+#if LOG_DEBUG
         log.debug("Decrypted payload %@", Data(decryptedPayload).hexadecimalString)
+#endif
         
         var msgCopy = msg
         msgCopy.payload = Data(decryptedPayload)
@@ -46,15 +50,19 @@ class EnDecrypt {
         let header = headerMessage.asData(forEncryption: true).subdata(in: 0..<16)
 
         let n = nonce.toData(sqn: nonceSeq, podReceiving: true)
+#if LOG_DEBUG
         log.debug("Encrypt Ck %@", ck.hexadecimalString)
         log.debug("Encrypt Header %@", header.hexadecimalString)
         log.debug("Encrypt Payload: %@", payload.hexadecimalString)
         log.debug("Encrypt Nonce %@", n.hexadecimalString)
+#endif
         let ccm = CCM(iv: n.bytes, tagLength: MAC_SIZE, messageLength: payload.count, additionalAuthenticatedData: header.bytes)
         let aes = try AES(key: ck.bytes, blockMode: ccm, padding: .noPadding)
         let encryptedPayload = try aes.encrypt(payload.bytes)
+#if LOG_DEBUG
         log.debug("Encrypted payload: %@", Data(encryptedPayload).subdata(in: 0..<(encryptedPayload.count - MAC_SIZE)).hexadecimalString)
         log.debug("Encrypt Tag: %@", Data(encryptedPayload).subdata(in: (encryptedPayload.count - MAC_SIZE)..<encryptedPayload.count).hexadecimalString)
+#endif
 
         var msgCopy = headerMessage
         msgCopy.payload = Data(encryptedPayload)

--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/Pair/LTKExchanger.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/Pair/LTKExchanger.swift
@@ -34,7 +34,9 @@ class LTKExchanger {
     }
 
     func negotiateLTK() throws -> PairResult {
+#if LOG_DEBUG
         log.debug("Sending sp1sp2")
+#endif
         let sp1sp2 = PairMessage(
             sequenceNumber: seq,
             source: ids.myId,
@@ -45,7 +47,9 @@ class LTKExchanger {
         try throwOnSendError(sp1sp2.message, LTKExchanger.SP1 + LTKExchanger.SP2)
 
         seq += 1
+#if LOG_DEBUG
         log.debug("Sending sps1")
+#endif
         let sps1 = PairMessage(
             sequenceNumber: seq,
             source: ids.myId,
@@ -55,7 +59,9 @@ class LTKExchanger {
         )
         try throwOnSendError(sps1.message, LTKExchanger.SPS1)
 
+#if LOG_DEBUG
         log.debug("Reading sps1")
+#endif
         let podSps1 = try manager.readMessagePacket()
         guard let _ = podSps1 else {
             throw PodProtocolError.pairingException("Could not read SPS1")
@@ -63,7 +69,9 @@ class LTKExchanger {
         try processSps1FromPod(podSps1!)
         // now we have all the data to generate: confPod, confPdm, ltk and noncePrefix
 
+#if LOG_DEBUG
         log.debug("Sending sps2")
+#endif
         seq += 1
         let sps2 = PairMessage(
             sequenceNumber: seq,
@@ -120,18 +128,26 @@ class LTKExchanger {
     }
 
     private func processSps1FromPod(_ msg: MessagePacket) throws {
+#if LOG_DEBUG
         log.debug("Received SPS1 from pod: %@", msg.payload.hexadecimalString)
+#endif
 
         let payload = try StringLengthPrefixEncoding.parseKeys([LTKExchanger.SPS1], msg.payload)[0]
+#if LOG_DEBUG
         log.debug("SPS1 payload from pod: %@", payload.hexadecimalString)
+#endif
         try keyExchange.updatePodPublicData(payload)
     }
 
     private func validatePodSps2(_ msg: MessagePacket) throws {
+#if LOG_DEBUG
         log.debug("Received SPS2 from pod: %@", msg.payload.hexadecimalString)
+#endif
 
         let payload = try StringLengthPrefixEncoding.parseKeys([LTKExchanger.SPS2], msg.payload)[0]
+#if LOG_DEBUG
         log.debug("SPS2 payload from pod: %@", payload.hexadecimalString)
+#endif
 
         if (payload.count != KeyExchange.CMAC_SIZE) {
             throw PodProtocolError.messageIOException("Invalid payload size")
@@ -146,10 +162,14 @@ class LTKExchanger {
     }
 
     private func validateP0(_ msg: MessagePacket) throws {
+#if LOG_DEBUG
         log.debug("Received P0 from pod: %@", msg.payload.hexadecimalString)
+#endif
 
         let payload = try StringLengthPrefixEncoding.parseKeys([LTKExchanger.P0], msg.payload)[0]
+#if LOG_DEBUG
         log.debug("P0 payload from pod: %@", payload.hexadecimalString)
+#endif
         if (payload != LTKExchanger.UNKNOWN_P0_PAYLOAD) {
             throw PodProtocolError.pairingException("Reveived invalid P0 payload: \(payload)")
         }

--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
@@ -20,7 +20,9 @@ extension PeripheralManager {
         dispatchPrecondition(condition: .onQueue(queue))
 
         let controllerId = Id.fromUInt32(myId).address
+#if LOG_DEFAULT
         log.default("Sending Hello %{public}@", controllerId.hexadecimalString)
+#endif
         guard let characteristic = peripheral.getCommandCharacteristic() else {
             throw PeripheralManagerError.notReady
         }
@@ -148,7 +150,9 @@ extension PeripheralManager {
         guard let characteristic = peripheral.getCommandCharacteristic() else {
             throw PeripheralManagerError.notReady
         }
+#if LOG_DEFAULT
         log.default("CMD >>> %{public}@", Data([command.rawValue]).hexadecimalString)
+#endif
         
         try writeValue(Data([command.rawValue]), for: characteristic, type: .withResponse, timeout: timeout)
     }
@@ -200,8 +204,10 @@ extension PeripheralManager {
         guard let characteristic = peripheral.getDataCharacteristic() else {
             throw PeripheralManagerError.notReady
         }
-        
+       
+#if LOG_DEFAULT 
         log.default("DATA >>> %{public}@", value.hexadecimalString)
+#endif
         
         try writeValue(value, for: characteristic, type: .withResponse, timeout: timeout)
     }
@@ -210,7 +216,9 @@ extension PeripheralManager {
     func waitForData(sequence: UInt8, timeout: TimeInterval) throws -> Data {
         dispatchPrecondition(condition: .onQueue(queue))
 
+#if LOG_DEFAULT
         log.default("waitForData sequence %02x", sequence)
+#endif
 
         // Wait for data to be read.
         queueLock.lock()
@@ -237,7 +245,9 @@ extension PeripheralManager {
                 log.error("waitForData failed data[0] != sequence (%d != %d).", data[0], sequence)
                 throw PeripheralManagerError.incorrectResponse
             }
+#if LOG_DEFAULT
             log.default("waitForData success %{public}@", data.hexadecimalString)
+#endif
             return data
         }
         

--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
@@ -157,7 +157,9 @@ extension PeripheralManager {
     func waitForCommand(_ command: PodCommand, timeout: TimeInterval = 5) throws {
         dispatchPrecondition(condition: .onQueue(queue))
 
+#if LOG_DEBUG
         log.debug("waitForCommand %{public}@", Data([command.rawValue]).hexadecimalString)
+#endif
         
         // Wait for data to be read.
         queueLock.lock()

--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/PeripheralManager.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/PeripheralManager.swift
@@ -122,7 +122,9 @@ extension PeripheralManager {
     func configureAndRun(_ block: @escaping (_ manager: PeripheralManager) -> Void) -> (() -> Void) {
         return {
             if self.needsReconnection {
+#if LOG_DEFAULT
                 self.log.default("Triggering forceful reconnect")
+#endif
                 do {
                     try self.reconnect(timeout: 5)
                 } catch let error {
@@ -136,17 +138,23 @@ extension PeripheralManager {
 
             if self.needsConfiguration || self.peripheral.services == nil {
                 do {
+#if LOG_DEFAULT
                     self.log.default("Applying configuration")
+#endif
                     try self.applyConfiguration()
                     self.needsConfiguration = false
 
                     if let delegate = self.delegate {
                         try delegate.completeConfiguration(for: self)
-                        
+                       
+#if LOG_DEFAULT 
                         self.log.default("Delegate configuration notified")
+#endif
                     }
 
+#if LOG_DEFAULT
                     self.log.default("Peripheral configuration completed")
+#endif
                 } catch let error {
                     self.log.error("Error applying peripheral configuration: %{public}@", String(describing: error))
                     // Will retry
@@ -173,7 +181,9 @@ extension PeripheralManager {
         try discoverServices(configuration.serviceCharacteristics.keys.map { $0 }, timeout: discoveryTimeout)
 
         for service in peripheral.services ?? [] {
+#if LOG_DEFAULT
             log.default("Discovered service: %{public}@", service)
+#endif
             guard let characteristics = configuration.serviceCharacteristics[service.uuid] else {
                 // Not all services may have characteristics
                 continue
@@ -341,7 +351,9 @@ extension PeripheralManager {
 extension PeripheralManager: CBPeripheralDelegate {
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+#if LOG_DEFAULT
         log.default("didDiscoverServices")
+#endif
         commandLock.lock()
 
         if let index = commandConditions.firstIndex(where: { (condition) -> Bool in
@@ -459,11 +471,15 @@ extension PeripheralManager {
     func clearCommsQueues() {
         queueLock.lock()
         if cmdQueue.count > 0 {
+#if LOG_DEFAULT
             self.log.default("Removing %{public}d leftover elements from command queue", cmdQueue.count)
+#endif
             cmdQueue.removeAll()
         }
         if dataQueue.count > 0 {
+#if LOG_DEFAULT
             self.log.default("Removing %{public}d leftover elements from data queue", dataQueue.count)
+#endif
             dataQueue.removeAll()
         }
         queueLock.unlock()
@@ -530,15 +546,23 @@ extension CBPeripheral {
 // MARK: - Command session management
 extension PeripheralManager {
     public func runSession(withName name: String , _ block: @escaping () -> Void) {
+#if LOG_DEFAULT
         self.log.default("Scheduling session %{public}@", name)
+#endif
 
         sessionQueue.addOperation({ [weak self] in
             self?.perform { (manager) in
+#if LOG_DEFAULT
                 manager.log.default("======================== %{public}@ ===========================", name)
+#endif
                 block()
+#if LOG_DEFAULT
                 manager.log.default("------------------------ %{public}@ ---------------------------", name)
+#endif
                 self?.idleStart = Date()
+#if LOG_DEFAULT
                 self?.log.default("Start of idle at %{public}@", String(describing: self?.idleStart))
+#endif
             }
         })
     }

--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/PeripheralManager.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/PeripheralManager.swift
@@ -476,11 +476,15 @@ extension PeripheralManager {
     }
 
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+#if LOG_DEBUG
         self.log.debug("PeripheralManager - didConnect: %@", peripheral)
+#endif
         switch peripheral.state {
         case .connected:
             clearCommsQueues()
+#if LOG_DEBUG
             self.log.debug("PeripheralManager - didConnect - running assertConfiguration")
+#endif
             assertConfiguration()
 
             commandLock.lock()

--- a/Dependencies/OmniBLE/OmniBLE/Bluetooth/Session/SessionEstablisher.swift
+++ b/Dependencies/OmniBLE/OmniBLE/Bluetooth/Session/SessionEstablisher.swift
@@ -104,7 +104,9 @@ class SessionEstablisher {
 
     private func assertIdentifier(msg: EapMessage) throws {
         if (msg.identifier != identifier) {
+#if LOG_DEBUG
             log.debug("EAP-AKA: got incorrect identifier ${msg.identifier} expected: $identifier")
+#endif
             throw SessionEstablishmentException.CommunicationError("Received incorrect EAP identifier: ${msg.identifier}")
         }
     }
@@ -142,7 +144,9 @@ class SessionEstablisher {
 
     private func assertValidAkaMessage(eapMsg: EapMessage) throws {
         if (eapMsg.attributes.count != 2) {
+#if LOG_DEBUG
             log.debug("EAP-AKA: got incorrect: $eapMsg")
+#endif
             if (eapMsg.attributes.count == 1 && eapMsg.attributes[0] is EapAkaAttributeClientErrorCode) {
                 throw SessionEstablishmentException.CommunicationError(
                     "Received CLIENT_ERROR_CODE for EAP-AKA challenge: ${eapMsg.attributes[0].toByteArray().toHex()}"

--- a/Dependencies/OmniBLE/OmniBLE/PumpManager/MessageTransport.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManager/MessageTransport.swift
@@ -246,7 +246,9 @@ class PodMessageTransport: MessageTransport {
             payloads: [cmd.encoded(), Data()]
         )
 
+#if LOG_DEBUG
         log.debug("Sending command: %@", wrapped.hexadecimalString)
+#endif
 
         let msg = MessagePacket(
             type: MessageType.ENCRYPTED,
@@ -272,14 +274,18 @@ class PodMessageTransport: MessageTransport {
         incrementNonceSeq()
         let decrypted = try enDecrypt.decrypt(readMessage, nonceSeq)
 
+#if LOG_DEBUG
         log.debug("Received response: %@", decrypted.payload.hexadecimalString)
+#endif
 
         let response = try parseResponse(decrypted: decrypted)
 
         incrementMsgSeq()
         incrementNonceSeq()
         let ack = try getAck(response: decrypted)
+#if LOG_DEBUG
         log.debug("Sending ACK: %@ in packet $ack", ack.payload.hexadecimalString)
+#endif
         let ackResult = manager.sendMessagePacket(ack)
         guard case .sentWithAcknowledgment = ackResult else {
             throw PodProtocolError.messageIOException("Could not write $msgType: \(ackResult)")

--- a/Dependencies/OmniBLE/OmniBLE/PumpManager/MessageTransport.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManager/MessageTransport.swift
@@ -208,7 +208,9 @@ class PodMessageTransport: MessageTransport {
         incrementMessageNumber() // bump to match expected Omnipod message # in response
 
         let dataToSend = message.encoded()
+#if LOG_DEFAULT
         log.default("Send(Hex): %{public}@", dataToSend.hexadecimalString)
+#endif
         messageLogger?.didSend(dataToSend)
 
         let sendMessage = try getCmdMessage(cmd: message)
@@ -309,7 +311,9 @@ class PodMessageTransport: MessageTransport {
         // so we ignore them as well and rely on higher level BLE & Dash message data checking to provide data corruption protection.
         let response = try Message(encodedData: data, checkCRC: false)
 
+#if LOG_DEFAULT
         log.default("Recv(Hex): %@", data.hexadecimalString)
+#endif
         messageLogger?.didReceive(data)
 
         return response

--- a/Dependencies/OmniBLE/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -807,7 +807,9 @@ extension OmniBLEPumpManager {
                 // We're on the session queue
                 session.assertOnSessionQueue()
 
+#if LOG_DEFAULT
                 self.log.default("Beginning pod prime")
+#endif
 
                 // Clean up any previously un-stored doses if needed
                 let unstoredDoses = self.state.unstoredDoses
@@ -839,7 +841,9 @@ extension OmniBLEPumpManager {
 
         if needsPairing {
 
+#if LOG_DEFAULT
             self.log.default("Pairing pod before priming")
+#endif
 
             guard let insulinType = insulinType else {
                 completion(.failure(.configuration(OmniBLEPumpManagerError.insulinTypeNotConfigured)))
@@ -862,7 +866,9 @@ extension OmniBLEPumpManager {
 
             })
         } else {
+#if LOG_DEFAULT
             self.log.default("Pod already paired. Continuing.")
+#endif
 
             self.podComms.runSession(withName: "Prime pod") { (result) in
                 // Calls completion
@@ -1225,7 +1231,9 @@ extension OmniBLEPumpManager {
     }
 
     public func setConfirmationBeeps(newPreference: BeepPreference, completion: @escaping (OmniBLEPumpManagerError?) -> Void) {
+#if LOG_DEFAULT
         self.log.default("Set Confirmation Beeps to %s", String(describing: newPreference))
+#endif
         guard self.hasActivePod else {
             self.setState { state in
                 state.confirmationBeeps = newPreference // set here to allow changes on a faulted Pod
@@ -1507,12 +1515,16 @@ extension OmniBLEPumpManager: PumpManager {
             completion?(lastSync)
             return // No active pod
         case true?:
+#if LOG_DEFAULT
             log.default("Fetching status because pumpData is too old")
+#endif
             getPodStatus() { (response) in
                 completion?(self.lastSync)
             }
         case false?:
+#if LOG_DEFAULT
             log.default("Skipping status update because pumpData is fresh")
+#endif
             completion?(self.lastSync)
             silenceAcknowledgedAlerts()
         }
@@ -1940,19 +1952,25 @@ extension OmniBLEPumpManager: PumpManager {
         let (added, removed) = oldAlerts.compare(to: newAlerts)
         for slot in added {
             if let podAlert = podState.configuredAlerts[slot] {
+#if LOG_DEFAULT
                 log.default("Alert slot triggered: %{public}@", String(describing: slot))
+#endif
                 if let pumpManagerAlert = getPumpManagerAlert(for: podAlert, slot: slot) {
                     issueAlert(alert: pumpManagerAlert)
                 } else {
+#if LOG_DEFAULT
                     log.default("Ignoring alert: %{public}@", String(describing: podAlert))
+#endif
                 }
             } else {
                 log.error("Unconfigured alert slot triggered: %{public}@", String(describing: slot))
             }
         }
+#if LOG_DEFAULT
         for alert in removed {
             log.default("Alert slot cleared: %{public}@", String(describing: alert))
         }
+#endif
     }
 
     private func getPumpManagerAlert(for podAlert: PodAlert, slot: AlertSlot) -> PumpManagerAlert? {
@@ -2073,12 +2091,16 @@ extension OmniBLEPumpManager: PumpManager {
 
 extension OmniBLEPumpManager: MessageLogger {
     func didSend(_ message: Data) {
+#if LOG_DEFAULT
         log.default("didSend: %{public}@", message.hexadecimalString)
+#endif
         self.logDeviceCommunication(message.hexadecimalString, type: .send)
     }
 
     func didReceive(_ message: Data) {
+#if LOG_DEFAULT
         log.default("didReceive: %{public}@", message.hexadecimalString)
+#endif
         self.logDeviceCommunication(message.hexadecimalString, type: .receive)
     }
 

--- a/Dependencies/OmniBLE/OmniBLE/PumpManager/PodComms.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManager/PodComms.swift
@@ -75,7 +75,9 @@ public class PodComms: CustomDebugStringConvertible {
     
     public func forgetPod() {
         if let manager = manager {
+#if LOG_DEFAULT
             self.log.default("Removing %{public}@ from auto-connect ids", manager.peripheral)
+#endif
             bluetoothManager.disconnectFromDevice(uuidString: manager.peripheral.identifier.uuidString)
         }
 
@@ -105,7 +107,9 @@ public class PodComms: CustomDebugStringConvertible {
                     let devices = self.bluetoothManager.getConnectedDevices()
 
                     if devices.count > 1 {
+#if LOG_DEFAULT
                         self.log.default("Multiple pods found while scanning")
+#endif
                         self.bluetoothManager.endPodDiscovery()
                         completion(.failure(PodCommsError.tooManyPodsFound))
                         timer.invalidate()
@@ -115,7 +119,9 @@ public class PodComms: CustomDebugStringConvertible {
 
                     // If we've found a pod by 2 seconds, let's go.
                     if elapsed > TimeInterval(seconds: 2) && devices.count > 0 {
+#if LOG_DEFAULT
                         self.log.default("Found pod!")
+#endif
                         let targetPod = devices.first!
                         self.bluetoothManager.connectToDevice(uuidString: targetPod.manager.peripheral.identifier.uuidString)
                         self.manager = targetPod.manager
@@ -126,7 +132,9 @@ public class PodComms: CustomDebugStringConvertible {
                     }
 
                     if elapsed > TimeInterval(seconds: 10) {
+#if LOG_DEFAULT
                         self.log.default("No pods found while scanning")
+#endif
                         self.bluetoothManager.endPodDiscovery()
                         completion(.failure(PodCommsError.noPodsFound))
                         timer.invalidate()
@@ -530,7 +538,9 @@ extension PodComms: OmniBLEConnectionDelegate {
 extension PodComms: PeripheralManagerDelegate {
     
     func completeConfiguration(for manager: PeripheralManager) throws {
+#if LOG_DEFAULT
         log.default("PodComms completeConfiguration: isPaired=%{public}@ needsSessionEstablishment=%{public}@", String(describing: self.isPaired), String(describing: needsSessionEstablishment))
+#endif
 
         if self.isPaired && needsSessionEstablishment {
             let myId = self.myId
@@ -551,7 +561,9 @@ extension PodComms: PeripheralManagerDelegate {
             }
 
         } else {
+#if LOG_DEFAULT
             log.default("Session already established.")
+#endif
         }
     }
 }

--- a/Dependencies/OmniBLE/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManager/PodCommsSession.swift
@@ -688,7 +688,9 @@ public class PodCommsSession {
             return CancelDeliveryResult.success(statusResponse: status, canceledDose: canceledDose)
         } catch PodCommsError.unacknowledgedMessage(let seq, let error) {
             podState.unacknowledgedCommand = podState.unacknowledgedCommand?.commsFinished
+#if LOG_DEBUG
             log.debug("Unacknowledged stop program: command seq = %d", seq)
+#endif
             return .unacknowledged(error: .commsError(error: error))
         } catch let error {
             podState.unacknowledgedCommand = nil
@@ -853,10 +855,14 @@ public class PodCommsSession {
             self.log.default("Recovering from unacknowledged command %{public}@, status = %{public}@", String(describing: pendingCommand), String(describing: status))
 
             if status.lastProgrammingMessageSeqNum == pendingCommand.sequence {
+#if LOG_DEBUG
                 self.log.debug("Unacknowledged command was received by pump")
+#endif
                 unacknowledgedCommandWasReceived(pendingCommand: pendingCommand, podStatus: status)
             } else {
+#if LOG_DEBUG
                 self.log.debug("Unacknowledged command was not received by pump")
+#endif
             }
             podState.unacknowledgedCommand = nil
         }

--- a/Dependencies/OmniBLE/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManager/PodCommsSession.swift
@@ -852,7 +852,9 @@ public class PodCommsSession {
 
     public func recoverUnacknowledgedCommand(using status: StatusResponse) {
         if let pendingCommand = podState.unacknowledgedCommand {
+#if LOG_DEFAULT
             self.log.default("Recovering from unacknowledged command %{public}@, status = %{public}@", String(describing: pendingCommand), String(describing: status))
+#endif
 
             if status.lastProgrammingMessageSeqNum == pendingCommand.sequence {
 #if LOG_DEBUG

--- a/Dependencies/OmniBLE/OmniBLEPlugin/OmniBLEPlugin.swift
+++ b/Dependencies/OmniBLE/OmniBLEPlugin/OmniBLEPlugin.swift
@@ -25,6 +25,8 @@ class OmniBLEPlugin: NSObject, PumpManagerUIPlugin {
 
     override init() {
         super.init()
+#if LOG_DEFAULT
         log.default("OmniBLEPlugin Instantiated")
+#endif
     }
 }

--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 		FE41E4D429463C660047FD55 /* NightscoutStatistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41E4D329463C660047FD55 /* NightscoutStatistics.swift */; };
 		FE41E4D629463EE20047FD55 /* NightscoutPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */; };
 		FE66D16B291F74F8005D6F77 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */; };
+		FEED49ED2997939B0091B949 /* LogSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED49EC299793900091B949 /* LogSettings.swift */; };
 		FEFFA7A22929FE49007B8193 /* UIDevice+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */; };
 /* End PBXBuildFile section */
 
@@ -771,6 +772,7 @@
 		FE41E4D329463C660047FD55 /* NightscoutStatistics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutStatistics.swift; sourceTree = "<group>"; };
 		FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutPreferences.swift; sourceTree = "<group>"; };
 		FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
+		FEED49EC299793900091B949 /* LogSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSettings.swift; sourceTree = "<group>"; };
 		FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1319,6 +1321,7 @@
 		388E5A5925B6F0250019842D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				FEED49EC299793900091B949 /* LogSettings.swift */,
 				385CEAC025F2EA52002D6D5B /* Announcement.swift */,
 				388E5A5F25B6F2310019842D /* Autosens.swift */,
 				38A00B1E25FC00F7006BC0B0 /* Autotune.swift */,
@@ -2207,6 +2210,7 @@
 				38AEE75725F0F18E0013F05B /* CarbsStorage.swift in Sources */,
 				38B4F3CA25E502E200E76A18 /* SwiftNotificationCenter.swift in Sources */,
 				38AEE75225F022080013F05B /* SettingsManager.swift in Sources */,
+				FEED49ED2997939B0091B949 /* LogSettings.swift in Sources */,
 				38FEF408273B011A00574A46 /* LibreTransmitterSource.swift in Sources */,
 				3894873A2614928B004DF424 /* DispatchTimer.swift in Sources */,
 				3895E4C625B9E00D00214B37 /* Preferences.swift in Sources */,

--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -338,6 +338,10 @@
 		FA630397F76B582C8D8681A7 /* BasalProfileEditorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42369F66CF91F30624C0B3A6 /* BasalProfileEditorProvider.swift */; };
 		FE41E4D429463C660047FD55 /* NightscoutStatistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41E4D329463C660047FD55 /* NightscoutStatistics.swift */; };
 		FE41E4D629463EE20047FD55 /* NightscoutPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */; };
+		FE6522E02998D76D0068B6D1 /* LogSettingsConfigDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6522DD2998D76C0068B6D1 /* LogSettingsConfigDataFlow.swift */; };
+		FE6522E12998D76D0068B6D1 /* LogSettingsConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6522DE2998D76C0068B6D1 /* LogSettingsConfigProvider.swift */; };
+		FE6522E22998D76D0068B6D1 /* LogSettingsConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6522DF2998D76D0068B6D1 /* LogSettingsConfigStateModel.swift */; };
+		FE6522E42998D77D0068B6D1 /* LogSettingsConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6522E32998D77D0068B6D1 /* LogSettingsConfigRootView.swift */; };
 		FE66D16B291F74F8005D6F77 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */; };
 		FEED49ED2997939B0091B949 /* LogSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED49EC299793900091B949 /* LogSettings.swift */; };
 		FEFFA7A22929FE49007B8193 /* UIDevice+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */; };
@@ -771,6 +775,10 @@
 		FBB3BAE7494CB771ABAC7B8B /* ISFEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorRootView.swift; sourceTree = "<group>"; };
 		FE41E4D329463C660047FD55 /* NightscoutStatistics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutStatistics.swift; sourceTree = "<group>"; };
 		FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutPreferences.swift; sourceTree = "<group>"; };
+		FE6522DD2998D76C0068B6D1 /* LogSettingsConfigDataFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LogSettingsConfigDataFlow.swift; path = LogSettingsConfig/LogSettingsConfigDataFlow.swift; sourceTree = "<group>"; };
+		FE6522DE2998D76C0068B6D1 /* LogSettingsConfigProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LogSettingsConfigProvider.swift; path = LogSettingsConfig/LogSettingsConfigProvider.swift; sourceTree = "<group>"; };
+		FE6522DF2998D76D0068B6D1 /* LogSettingsConfigStateModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LogSettingsConfigStateModel.swift; path = LogSettingsConfig/LogSettingsConfigStateModel.swift; sourceTree = "<group>"; };
+		FE6522E32998D77D0068B6D1 /* LogSettingsConfigRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LogSettingsConfigRootView.swift; path = LogSettingsConfig/View/LogSettingsConfigRootView.swift; sourceTree = "<group>"; };
 		FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
 		FEED49EC299793900091B949 /* LogSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSettings.swift; sourceTree = "<group>"; };
 		FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extensions.swift"; sourceTree = "<group>"; };
@@ -918,6 +926,10 @@
 		3811DE0325C9D31700A708ED /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				FE6522E32998D77D0068B6D1 /* LogSettingsConfigRootView.swift */,
+				FE6522DD2998D76C0068B6D1 /* LogSettingsConfigDataFlow.swift */,
+				FE6522DE2998D76C0068B6D1 /* LogSettingsConfigProvider.swift */,
+				FE6522DF2998D76D0068B6D1 /* LogSettingsConfigStateModel.swift */,
 				F90692CD274B99850037068D /* HealthKit */,
 				6DC5D590658EF8B8DF94F9F5 /* AddCarbs */,
 				A9A4C88374496B3C89058A89 /* AddTempTarget */,
@@ -2322,6 +2334,7 @@
 				1935364028496F7D001E0B16 /* TDD_averages.swift in Sources */,
 				38E4453A274E411700EC9A94 /* Disk+[UIImage].swift in Sources */,
 				72F1BD388F42FCA6C52E4500 /* ConfigEditorProvider.swift in Sources */,
+				FE6522E12998D76D0068B6D1 /* LogSettingsConfigProvider.swift in Sources */,
 				E39E418C56A5A46B61D960EE /* ConfigEditorStateModel.swift in Sources */,
 				45717281F743594AA9D87191 /* ConfigEditorRootView.swift in Sources */,
 				D6DEC113821A7F1056C4AA1E /* NightscoutConfigDataFlow.swift in Sources */,
@@ -2330,6 +2343,7 @@
 				9825E5E923F0B8FA80C8C7C7 /* NightscoutConfigStateModel.swift in Sources */,
 				38A43598262E0E4900E80935 /* FetchAnnouncementsManager.swift in Sources */,
 				642F76A05A4FF530463A9FD0 /* NightscoutConfigRootView.swift in Sources */,
+				FE6522E22998D76D0068B6D1 /* LogSettingsConfigStateModel.swift in Sources */,
 				AD3D2CD42CD01B9EB8F26522 /* PumpConfigDataFlow.swift in Sources */,
 				53F2382465BF74DB1A967C8B /* PumpConfigProvider.swift in Sources */,
 				5D16287A969E64D18CE40E44 /* PumpConfigStateModel.swift in Sources */,
@@ -2366,6 +2380,7 @@
 				38192E0D261BAF980094D973 /* ConvenienceExtensions.swift in Sources */,
 				88AB39B23C9552BD6E0C9461 /* ISFEditorRootView.swift in Sources */,
 				F816825E28DB441200054060 /* HeartBeatManager.swift in Sources */,
+				FE6522E42998D77D0068B6D1 /* LogSettingsConfigRootView.swift in Sources */,
 				38FEF413273B317A00574A46 /* HKUnit.swift in Sources */,
 				A33352ED40476125EBAC6EE0 /* CREditorDataFlow.swift in Sources */,
 				17A9D0899046B45E87834820 /* CREditorProvider.swift in Sources */,
@@ -2379,6 +2394,7 @@
 				E13B7DAB2A435F57066AF02E /* TargetsEditorStateModel.swift in Sources */,
 				9702FF92A09C53942F20D7EA /* TargetsEditorRootView.swift in Sources */,
 				38E8754F275556FA00975559 /* WatchManager.swift in Sources */,
+				FE6522E02998D76D0068B6D1 /* LogSettingsConfigDataFlow.swift in Sources */,
 				A228DF96647338139F152B15 /* PreferencesEditorDataFlow.swift in Sources */,
 				19F79FA9283AE7E000646323 /* TDD.swift in Sources */,
 				389ECE052601144100D86C4F /* ConcurrentMap.swift in Sources */,

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -175,6 +175,9 @@ final class BaseAPSManager: APSManager, Injectable {
 
     // Loop entry point
     private func loop() {
+        #if CHECKPOINT_LOGGING
+            debug(.checkpoint, "BEGIN")
+        #endif
         guard !isLooping.value else {
             warning(.apsManager, "Already looping, skip")
             return
@@ -222,6 +225,9 @@ final class BaseAPSManager: APSManager, Injectable {
                 }
             } receiveValue: {}
             .store(in: &lifetime)
+        #if CHECKPOINT_LOGGING
+            debug(.checkpoint, "END")
+        #endif
     }
 
     // Loop exit point

--- a/FreeAPS/Sources/APS/OpenAPS/Constants.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/Constants.swift
@@ -28,6 +28,7 @@ extension OpenAPS {
 
     enum Settings {
         static let preferences = "preferences.json"
+        static let logsettings = "logsettings.json"
         static let autotune = "settings/autotune.json"
         static let autosense = "settings/autosense.json"
         static let profile = "settings/profile.json"

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -58,6 +58,8 @@ final class OpenAPS {
                 // determine-basal
                 let reservoir = self.loadFileFromStorage(name: Monitor.reservoir)
 
+                let logsettings = self.loadFileFromStorage(name: Settings.logsettings)
+
                 let preferences = self.loadFileFromStorage(name: Settings.preferences)
 
                 let suggested = self.determineBasal(

--- a/FreeAPS/Sources/Logger/Logger.swift
+++ b/FreeAPS/Sources/Logger/Logger.swift
@@ -111,6 +111,9 @@ final class Logger {
     static let deviceManager = Logger(category: .deviceManager, reporter: baseReporter)
     static let apsManager = Logger(category: .apsManager, reporter: baseReporter)
     static let nightscout = Logger(category: .nightscout, reporter: baseReporter)
+    #if CHECKPOINT_LOGGING
+        static let checkpoint = Logger(category: .checkpoint, reporter: baseReporter)
+    #endif
 
     enum Category: String {
         case `default`
@@ -120,6 +123,9 @@ final class Logger {
         case deviceManager
         case apsManager
         case nightscout
+        #if CHECKPOINT_LOGGING
+            case checkpoint
+        #endif
 
         var name: String {
             rawValue.capitalizingFirstLetter()
@@ -134,6 +140,9 @@ final class Logger {
             case .deviceManager: return .deviceManager
             case .apsManager: return .apsManager
             case .nightscout: return .nightscout
+            #if CHECKPOINT_LOGGING
+                case .checkpoint: return .checkpoint
+            #endif
             }
         }
 
@@ -141,6 +150,10 @@ final class Logger {
             let subsystem = Bundle.main.bundleIdentifier!
             switch self {
             case .default: return OSLog.default
+            #if CHECKPOINT_LOGGING
+                case .checkpoint:
+                    return OSLog(subsystem: subsystem, category: name)
+            #endif
             case .apsManager,
                  .businessLogic,
                  .deviceManager,

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -25,6 +25,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var carbsRequiredThreshold: Decimal = 10
     var animatedBackground: Bool = false
     var displayStatistics: Bool = false
+    var omniBLEDebug: Bool = false
 }
 
 extension FreeAPSSettings: Decodable {
@@ -130,6 +131,10 @@ extension FreeAPSSettings: Decodable {
 
         if let displayStatistics = try? container.decode(Bool.self, forKey: .displayStatistics) {
             settings.displayStatistics = displayStatistics
+        }
+
+        if let omniBLEDebug = try? container.decode(Bool.self, forKey: .omniBLEDebug) {
+            settings.omniBLEDebug = omniBLEDebug
         }
 
         self = settings

--- a/FreeAPS/Sources/Models/LogSettings.swift
+++ b/FreeAPS/Sources/Models/LogSettings.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 struct LogSettings: JSON {
-    var checkpointLogging: Bool = false
+    var omniBLEDebug: Bool = false
 }
 
 extension LogSettings {
     private enum CodingKeys: String, CodingKey {
-        case checkpointLogging = "checkpoint_logging"
+        case omniBLEDebug = "omnible_debug"
     }
 }

--- a/FreeAPS/Sources/Models/LogSettings.swift
+++ b/FreeAPS/Sources/Models/LogSettings.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct LogSettings: JSON {
+    var checkpointLogging: Bool = false
+}
+
+extension LogSettings {
+    private enum CodingKeys: String, CodingKey {
+        case checkpointLogging = "checkpoint_logging"
+    }
+}

--- a/FreeAPS/Sources/Modules/LogSettingsConfig/LogSettingsConfigDataFlow.swift
+++ b/FreeAPS/Sources/Modules/LogSettingsConfig/LogSettingsConfigDataFlow.swift
@@ -1,0 +1,5 @@
+enum LogSettingsConfig {
+    enum Config {}
+}
+
+protocol LogSettingsConfigProvider: Provider {}

--- a/FreeAPS/Sources/Modules/LogSettingsConfig/LogSettingsConfigProvider.swift
+++ b/FreeAPS/Sources/Modules/LogSettingsConfig/LogSettingsConfigProvider.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension LogSettingsConfig {
+    final class Provider: BaseProvider, LogSettingsConfigProvider {
+        @Injected() private var settingsManager: SettingsManager!
+        private let processQueue = DispatchQueue(label: "LogSettingsProvider.processQueue")
+
+        var logSettings: LogSettings {
+            settingsManager.logSettings
+        }
+
+        func saveLogSettingsConfig(_ logSettings: LogSettings) {
+            processQueue.async {
+                self.storage.save(logSettings, as: OpenAPS.Settings.logsettings)
+            }
+        }
+    }
+}

--- a/FreeAPS/Sources/Modules/LogSettingsConfig/LogSettingsConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/LogSettingsConfig/LogSettingsConfigStateModel.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+extension LogSettingsConfig {
+    final class StateModel: BaseStateModel<Provider> {
+        @Published var omniBLEDebug = false
+
+        override func subscribe() {
+            subscribeSetting(\.omniBLEDebug, on: $omniBLEDebug) { omniBLEDebug = $0 }
+        }
+    }
+}

--- a/FreeAPS/Sources/Modules/LogSettingsConfig/View/LogSettingsConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/LogSettingsConfig/View/LogSettingsConfigRootView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import Swinject
+
+extension LogSettingsConfig {
+    struct RootView: BaseView {
+        let resolver: Resolver
+        @StateObject var state = StateModel()
+
+        var body: some View {
+            Form {
+                Section {
+                    Toggle("Enable OmniBLE Debug Logs", isOn: $state.omniBLEDebug)
+                }
+            }
+            .onAppear(perform: configureView)
+            .navigationTitle("Log Settings")
+            .navigationBarTitleDisplayMode(.automatic)
+        }
+    }
+}

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -112,7 +112,8 @@ extension Settings {
                     Toggle("Animated Background", isOn: $state.animatedBackground)
                 }
 
-                Section {
+                Section(header: Text("Logs")) {
+                    Text("Log Settings").navigationLink(to: .logSettingsConfig, from: self)
                     Text("Share logs")
                         .onTapGesture {
                             showShareSheet = true

--- a/FreeAPS/Sources/Router/Screen.swift
+++ b/FreeAPS/Sources/Router/Screen.swift
@@ -14,6 +14,7 @@ enum Screen: Identifiable, Hashable {
     case crEditor
     case targetsEditor
     case preferencesEditor
+    case logSettingsConfig
     case addCarbs
     case addTempTarget
     case bolus(waitForSuggestion: Bool)
@@ -60,6 +61,8 @@ extension Screen {
             TargetsEditor.RootView(resolver: resolver)
         case .preferencesEditor:
             PreferencesEditor.RootView(resolver: resolver)
+        case .logSettingsConfig:
+            LogSettingsConfig.RootView(resolver: resolver)
         case .addCarbs:
             AddCarbs.RootView(resolver: resolver)
         case .addTempTarget:

--- a/FreeAPS/Sources/Services/SettingsManager/SettingsManager.swift
+++ b/FreeAPS/Sources/Services/SettingsManager/SettingsManager.swift
@@ -4,6 +4,7 @@ import Swinject
 
 protocol SettingsManager: AnyObject {
     var settings: FreeAPSSettings { get set }
+    var logSettings: LogSettings { get }
     var preferences: Preferences { get }
     var pumpSettings: PumpSettings { get }
     func updateInsulinCurve(_ insulinType: InsulinType?)
@@ -41,6 +42,12 @@ final class BaseSettingsManager: SettingsManager, Injectable {
 
     private func save() {
         storage.save(settings, as: OpenAPS.FreeAPS.settings)
+    }
+
+    var logSettings: LogSettings {
+        storage.retrieve(OpenAPS.Settings.logsettings, as: LogSettings.self)
+            ?? LogSettings(from: OpenAPS.defaults(for: OpenAPS.Settings.logsettings))
+            ?? LogSettings()
     }
 
     var preferences: Preferences {


### PR DESCRIPTION
This is a sample ... if acceptable, will expand it throughout the code base, with the idea that it will hopefully be easier to isolate the recent crashes to a specific function.

To enable, you would add -DCHECKPOINT_LOGGING to

Target -> FreeAPS -> Build Settings -> Swift Compiler - Custom Flags

   - Under "Other Swift Flags"

This could be extended to other areas of logging so that log.txt is quieter unless there is debugging going on ( ie. get rid of all of the DEV messages concerning OmniBLE for a regular build, shrinking log.txt by almost 50%, and saving alot of calls to debug(), and writes to the file system