### PR TITLE
Crashes

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -338,6 +338,7 @@
 		FA630397F76B582C8D8681A7 /* BasalProfileEditorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42369F66CF91F30624C0B3A6 /* BasalProfileEditorProvider.swift */; };
 		FE41E4D429463C660047FD55 /* NightscoutStatistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41E4D329463C660047FD55 /* NightscoutStatistics.swift */; };
 		FE41E4D629463EE20047FD55 /* NightscoutPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */; };
+		FE66611A299B43DF00A2DBF3 /* Restarts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE666119299B43DF00A2DBF3 /* Restarts.swift */; };
 		FE66D16B291F74F8005D6F77 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */; };
 		FEFFA7A22929FE49007B8193 /* UIDevice+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */; };
 /* End PBXBuildFile section */
@@ -770,6 +771,7 @@
 		FBB3BAE7494CB771ABAC7B8B /* ISFEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorRootView.swift; sourceTree = "<group>"; };
 		FE41E4D329463C660047FD55 /* NightscoutStatistics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutStatistics.swift; sourceTree = "<group>"; };
 		FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutPreferences.swift; sourceTree = "<group>"; };
+		FE666119299B43DF00A2DBF3 /* Restarts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Restarts.swift; sourceTree = "<group>"; };
 		FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
 		FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1319,6 +1321,7 @@
 		388E5A5925B6F0250019842D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				FE666119299B43DF00A2DBF3 /* Restarts.swift */,
 				385CEAC025F2EA52002D6D5B /* Announcement.swift */,
 				388E5A5F25B6F2310019842D /* Autosens.swift */,
 				38A00B1E25FC00F7006BC0B0 /* Autotune.swift */,
@@ -2395,6 +2398,7 @@
 				E0D4F80527513ECF00BDF1FE /* HealthKitSample.swift in Sources */,
 				919DBD08F13BAFB180DF6F47 /* AddTempTargetStateModel.swift in Sources */,
 				8BC2F5A29AD1ED08AC0EE013 /* AddTempTargetRootView.swift in Sources */,
+				FE66611A299B43DF00A2DBF3 /* Restarts.swift in Sources */,
 				38A00B1F25FC00F7006BC0B0 /* Autotune.swift in Sources */,
 				38AAF85525FFF846004AF583 /* CurrentGlucoseView.swift in Sources */,
 				041D1E995A6AE92E9289DC49 /* BolusDataFlow.swift in Sources */,

--- a/FreeAPS/Sources/APS/OpenAPS/Constants.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/Constants.swift
@@ -58,6 +58,7 @@ extension OpenAPS {
         static let tdd_averages = "monitor/tdd_averages.json"
         static let alertHistory = "monitor/alerthistory.json"
         static let statistics = "monitor/statistics.json"
+        static let restarts = "monitor/restarts.json"
         static let loopStats = "monitor/loopStats.json"
         static let glucose_data = "monitor/glucoseForStats.json"
     }

--- a/FreeAPS/Sources/Models/Restarts.swift
+++ b/FreeAPS/Sources/Models/Restarts.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct Restarts: JSON, Equatable {
+    var created_at: Date
+    var Build_Version: String
+    var Build_Number: String
+    var Build_Date: Date
+
+    init(
+        created_at: Date,
+        Build_Version: String,
+        Build_Number: String,
+        Build_Date: Date
+    ) {
+        self.created_at = created_at
+        self.Build_Version = Build_Version
+        self.Build_Number = Build_Number
+        self.Build_Date = Build_Date
+    }
+
+    static func == (lhs: Restarts, rhs: Restarts) -> Bool {
+        lhs.created_at == rhs.created_at
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(created_at)
+    }
+}
+
+extension Restarts {
+    private enum CodingKeys: String, CodingKey {
+        case created_at
+        case Build_Version
+        case Build_Number
+        case Build_Date
+    }
+}


### PR DESCRIPTION
This adds a new file monitor/restarts.json to contains the last 24h of restarts ... might need to extend this further back, but the idea is that this can be pulled into statistics.json ( and the statistics display on main screen ) to show # of app restarts

a restart *can* be a simple "I installed / updated app", which could be a high number for a developer, but in normal operation, this *should* be 0 or 1, most of the time, for end users

the file contains build date, as well as version / build number ... if build date = build date, very good chance its a crash and not a developer updating the app

its not perfect, but it provides a clue to check the crash reports under Analytics Data to see if there was, in fact, an actual crash
